### PR TITLE
compose: Add .dev config for docker

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+services:
+  dev-qwik-app:
+    extends:
+      file: docker-compose.yml
+      service: my-qwik-app
+    volumes:
+      - node_modules_cache:/app/node_modules/
+      - ./:/app
+    command: sh -c "npm install &&  npm run dev"
+
+
+volumes:
+  node_modules_cache:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build.preview": "vite build --ssr src/entry.preview.tsx",
     "build.types": "tsc --incremental --noEmit",
     "deploy": "echo 'Run \"npm run qwik add\" to install a server adapter'",
-    "dev": "vite --mode ssr",
+    "dev": "vite --mode ssr --host",
     "dev.debug": "node --inspect-brk ./node_modules/vite/bin/vite.js --mode ssr --force",
     "fmt": "prettier --write .",
     "fmt.check": "prettier --check .",


### PR DESCRIPTION
Changes:

- New `docker.compose.dev.yml` file:
  - Mount local volume to `/app` for hot reloading
  - Cache node_modules for faster setting up
  - Overwrite run command to install missing dependencies and run `npm run dev` instead
- Modify `package.json` to pass the `--host` option when running `npm run dev`

With those modifications we can access the web locally at `http://localhost:5173/`. To run the development environment we should use `-f` option to specify the new `yml` file like this:

```
docker compose -f docker-compose.dev.yml up
```

With these changes if there's a change in the code, `vite` recognizes it and hot reloads our web, i.e.:

```
my-qwik-container  | > dev
my-qwik-container  | > vite --mode ssr --host
my-qwik-container  | 
my-qwik-container  | 
my-qwik-container  |   VITE v4.5.0  ready in 1140 ms
my-qwik-container  | 
my-qwik-container  |   ➜  Local:   http://localhost:5173/
my-qwik-container  |   ➜  Network: http://172.23.0.2:5173/
my-qwik-container  | 
my-qwik-container  |   ❗️ Expect significant performance loss in development.
my-qwik-container  |   ❗️ Disabling the browser's cache results in waterfall requests.
my-qwik-container  | Starting SSR server...
my-qwik-container  | 3:45:46 PM [vite] page reload src/components/starter/hero/hero.tsx
my-qwik-container  | Starting SSR server...
my-qwik-container  | 3:46:01 PM [vite] page reload src/components/starter/hero/hero.tsx
my-qwik-container  | Starting SSR server...
```